### PR TITLE
Add webapp skeleton with theme options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# codex-gpt
-teste do codex gpt
+# Webapp de Lista de Tarefas
+
+Este projeto é uma aplicação web simples para gerenciamento de tarefas (To-Do List). Não há dependências externas nem backend; todo o estado é armazenado no `localStorage` do navegador.
+
+## Como usar
+
+1. Clone o repositório ou baixe os arquivos.
+2. Abra o arquivo `index.html` em um navegador moderno.
+3. Adicione, marque como concluídas ou remova tarefas conforme necessário. Suas tarefas permanecem salvas no navegador mesmo após fechar a página.
+4. Escolha o tema (claro, escuro ou sistema) no seletor "Tema" para personalizar a aparência. A escolha fica armazenada no navegador.
+
+## Estrutura
+
+- `index.html` — estrutura principal da página.
+- `style.css` — estilos da interface e definição dos temas claro/escuro.
+- `script.js` — lógica de funcionamento da lista de tarefas, incluindo persistência em `localStorage`.
+
+Este projeto foi criado para demonstrar um exemplo simples de webapp funcional sem o uso de frameworks.
+
+## Hospedagem no GitHub Pages
+
+Após enviar os arquivos para o repositório [bebetoh/codex-gpt](https://github.com/bebetoh/codex-gpt),
+ative a opção **GitHub Pages** nas configurações e selecione a branch de onde será feita a publicação.
+O aplicativo ficará disponível em:
+
+<https://bebetoh.github.io/codex-gpt/>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Lista de Tarefas</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Lista de Tarefas</h1>
+        <!-- Seletor de tema -->
+        <div class="theme-selector">
+            <label for="theme-select">Tema:</label>
+            <select id="theme-select">
+                <option value="system">Sistema</option>
+                <option value="light">Claro</option>
+                <option value="dark">Escuro</option>
+            </select>
+        </div>
+        <!-- Campo para adicionar novas tarefas -->
+        <div class="new-task">
+            <input type="text" id="task-input" placeholder="Adicionar nova tarefa" />
+            <button id="add-button">Adicionar</button>
+        </div>
+        <!-- Lista de tarefas -->
+        <ul id="task-list"></ul>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,102 @@
+// Elementos da interface
+const taskInput = document.getElementById('task-input');
+const addButton = document.getElementById('add-button');
+const taskList = document.getElementById('task-list');
+const themeSelect = document.getElementById('theme-select');
+
+let tasks = [];
+
+// Carrega as tarefas salvas do localStorage
+function loadTasks() {
+    const stored = localStorage.getItem('tasks');
+    tasks = stored ? JSON.parse(stored) : [];
+}
+
+// Salva a lista atual de tarefas no localStorage
+function saveTasks() {
+    localStorage.setItem('tasks', JSON.stringify(tasks));
+}
+
+// Atualiza a lista na tela
+function renderTasks() {
+    taskList.innerHTML = '';
+    tasks.forEach(task => {
+        const li = document.createElement('li');
+        li.className = 'task-item' + (task.completed ? ' completed' : '');
+
+        const label = document.createElement('label');
+        label.textContent = task.text;
+
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = task.completed;
+        checkbox.addEventListener('change', () => {
+            task.completed = checkbox.checked;
+            saveTasks();
+            renderTasks();
+        });
+
+        const deleteBtn = document.createElement('button');
+        deleteBtn.textContent = 'Excluir';
+        deleteBtn.className = 'delete-button';
+        deleteBtn.addEventListener('click', () => {
+            tasks = tasks.filter(t => t.id !== task.id);
+            saveTasks();
+            renderTasks();
+        });
+
+        li.appendChild(checkbox);
+        li.appendChild(label);
+        li.appendChild(deleteBtn);
+        taskList.appendChild(li);
+    });
+}
+
+// Aplica o tema selecionado (claro, escuro ou sistema)
+function applyTheme(theme) {
+    if (theme === 'system') {
+        document.documentElement.removeAttribute('data-theme');
+    } else {
+        document.documentElement.setAttribute('data-theme', theme);
+    }
+}
+
+// Carrega a preferência de tema salva
+function loadTheme() {
+    const stored = localStorage.getItem('theme') || 'system';
+    themeSelect.value = stored;
+    applyTheme(stored);
+}
+
+// Adiciona uma nova tarefa na lista
+addButton.addEventListener('click', () => {
+    const text = taskInput.value.trim();
+    if (!text) return;
+    const newTask = {
+        id: Date.now(),
+        text,
+        completed: false
+    };
+    tasks.push(newTask);
+    saveTasks();
+    renderTasks();
+    taskInput.value = '';
+});
+
+// Permite adicionar tarefas pressionando Enter
+taskInput.addEventListener('keypress', e => {
+    if (e.key === 'Enter') {
+        addButton.click();
+    }
+});
+
+// Alteração do tema pela interface
+themeSelect.addEventListener('change', () => {
+    const theme = themeSelect.value;
+    localStorage.setItem('theme', theme);
+    applyTheme(theme);
+});
+
+loadTasks();
+loadTheme();
+renderTasks();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,115 @@
+/* Cores padrão (modo claro) */
+:root {
+    --bg-color: #f4f4f4;
+    --text-color: #000;
+    --container-bg: #fff;
+    --shadow-color: rgba(0,0,0,0.1);
+    --item-border: #ddd;
+    --completed-color: #888;
+    --delete-color: #c00;
+}
+
+/* Paleta escura automática, caso o sistema do usuário use dark mode */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-color: #121212;
+        --text-color: #eee;
+        --container-bg: #1e1e1e;
+        --shadow-color: rgba(0,0,0,0.5);
+        --item-border: #333;
+        --completed-color: #aaa;
+        --delete-color: #e66;
+    }
+}
+
+[data-theme='light'] {
+    --bg-color: #f4f4f4;
+    --text-color: #000;
+    --container-bg: #fff;
+    --shadow-color: rgba(0,0,0,0.1);
+    --item-border: #ddd;
+    --completed-color: #888;
+    --delete-color: #c00;
+}
+
+[data-theme='dark'] {
+    --bg-color: #121212;
+    --text-color: #eee;
+    --container-bg: #1e1e1e;
+    --shadow-color: rgba(0,0,0,0.5);
+    --item-border: #333;
+    --completed-color: #aaa;
+    --delete-color: #e66;
+}
+
+body {
+    font-family: Arial, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    margin: 0;
+    padding: 0;
+}
+
+.container {
+    max-width: 600px;
+    margin: 50px auto;
+    background: var(--container-bg);
+    padding: 20px;
+    box-shadow: 0 0 10px var(--shadow-color);
+}
+
+.new-task {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 20px;
+}
+
+.theme-selector {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    margin-bottom: 10px;
+}
+
+#theme-select {
+    padding: 4px;
+    font-size: 14px;
+}
+
+#task-input {
+    flex: 1;
+    padding: 8px;
+    font-size: 16px;
+}
+
+#add-button {
+    padding: 8px 12px;
+    font-size: 16px;
+    cursor: pointer;
+}
+
+#task-list {
+    list-style: none;
+    padding: 0;
+}
+
+.task-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px;
+    border-bottom: 1px solid var(--item-border);
+}
+
+.task-item.completed label {
+    text-decoration: line-through;
+    color: var(--completed-color);
+}
+
+.delete-button {
+    background: none;
+    border: none;
+    color: var(--delete-color);
+    cursor: pointer;
+    font-size: 16px;
+}


### PR DESCRIPTION
## Summary
- create to-do list webapp
- add light, dark and system theme selector
- persist tasks and theme in localStorage
- improve docs in Portuguese
- add inline comments

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_6844dab241808322a5720d79a3ca9e68